### PR TITLE
adds optional chaining to the eslint and babel configs

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,1 +1,2 @@
 export const presets = ['@babel/preset-env'];
+export const plugins = ['@babel/plugin-proposal-optional-chaining'];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,10 @@ export default [
   {
     languageOptions: {
       globals: globals.browser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+      },
     },
     ignores: [
       './node_modules',


### PR DESCRIPTION
This PR configs Babel and ESLint to allow optional chaining.
[Ticket](https://github.com/NoroffFEU/yeetsheet/issues/100)