### PR TITLE
WCAG compliant link

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
           <div class="mr-24">
             <a href="index.html" class="p-3">
               <span data-icon="logo" data-size="54" data-class=""></span>
+              <span class="sr-only">Homepage</span>
             </a>
           </div>
           <nav class="flex flex-1 justify-start">

--- a/src/index.css
+++ b/src/index.css
@@ -112,3 +112,15 @@ svg {
   height: 100%;
   min-height: 5em;
 }
+
+/* Styling for empty buttons and links for WCAG compliance */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}


### PR DESCRIPTION
Added a span that is read only by screen readers to let the user know that they navigate to the homepage by clicking the logo. Last commit did not resolve the issue. 