### PR TITLE
WCAG compliance for empty buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,6 +240,7 @@
               data-class="text-ys-backgroundAndText dark:text-ys-textAndIconsLight"
               alt="Open Menu"
             ></span>
+            <span class="sr-only">Open menu</span>
           </button>
           <div class="flex justify-between items-center w-full">
             <p class="text-sm uppercase">Project name</p>
@@ -251,6 +252,7 @@
                 data-class="text-ys-textAndIconsLight"
                 alt="Edit Project Name"
               ></span>
+              <span class="sr-only">Edit project name</span>
             </button>
           </div>
           <button


### PR DESCRIPTION
Added a new span only read by screen readers inside buttons without text to make the site WCAG compliant.