### PR TITLE
Move unit tests to their appropriate location

### DIFF
--- a/src/js/console/consoleBtns.test.js
+++ b/src/js/console/consoleBtns.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import consoleBtnsActiveState from '../../console/consoleBtns.mjs';
+import consoleBtnsActiveState from './consoleBtns.mjs';
 
 describe('consoleBtnsActiveState', () => {
   let btns;

--- a/src/js/darkModeToggle/darkModeToggle.test.js
+++ b/src/js/darkModeToggle/darkModeToggle.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import toggleDarkMode from '../../darkModeToggle/toggleDarkMode.mjs';
+import toggleDarkMode from './toggleDarkMode.mjs';
 
 describe('toggleDarkMode', () => {
   let darkModeToggleBtn;

--- a/src/js/header/menu.test.js
+++ b/src/js/header/menu.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { showDropdownMenu } from '../../header/menu.mjs';
+import { showDropdownMenu } from './menu.mjs';
 
 vi.mock('../helpers/closeOnOutsideClick.mjs', () => ({
   default: vi.fn(),


### PR DESCRIPTION
Reorganized the unit tests by moving them closer to the corresponding functions they test.

Link to ticket:
#119