### PR TITLE
scrollbar styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -139,10 +139,18 @@ li button:hover {
 }
 
 /* Highlight for rows / columns */
-.highlight-row, .highlight-column {
-  background-color: rgba(213, 95, 168, 0.3); 
+.highlight-row,
+.highlight-column {
+  background-color: rgba(213, 95, 168, 0.3);
 }
 
 .spreadsheet-container th {
-  cursor: pointer; 
+  cursor: pointer;
+}
+
+/* scrollbar */
+
+#spreadsheetContainer {
+  scrollbar-color: #2d2b43 #0b0821;
+  scrollbar-width: auto;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -150,7 +150,12 @@ li button:hover {
 
 /* scrollbar */
 
-#spreadsheetContainer {
+.dark #spreadsheetContainer {
   scrollbar-color: #2d2b43 #0b0821;
+  scrollbar-width: auto;
+}
+
+#spreadsheetContainer {
+  scrollbar-color: #9e9ac8 #e0dff1;
   scrollbar-width: auto;
 }


### PR DESCRIPTION
Change of color for scrollbars on spreadsheet.

Limited support for browsers using webkit, so decided not to.
Screenshot from mdn: 
<img width="793" alt="Screenshot 2024-10-10 at 12 06 15" src="https://github.com/user-attachments/assets/e1d5950e-7494-4f5b-bab6-d3a363f546cf">
Link to article: https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar

Scrollbar thumb and track is correct colors based on figma design, however I did not find any ways to get it even closer to the design.

Link to ticket: 
https://github.com/NoroffFEU/yeetsheet/issues/203
